### PR TITLE
Fixing S3 directory check and Kubernetes executor waiting for pod running, env variable support

### DIFF
--- a/storage/generic_s3.go
+++ b/storage/generic_s3.go
@@ -50,7 +50,7 @@ func isDir(minioClient *minio.Client, bucketName, objectName string) (bool, erro
 		}
 
 		// If any object's key starts with the objectName and is not equal, it's a directory
-		if strings.HasPrefix(object.Key, objectName) && object.Key != objectName {
+		if strings.HasPrefix(object.Key, objectName+"/") && object.Key != objectName {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
## S3 Path Directory Check Fix
Corrects the logic used to determine whether an S3 path is a directory. Previously, a file could be mistakenly identified as a directory if another object existed with a similar prefix.
Example:
The path `/path/to/file.txt` was incorrectly treated as a directory if `/path/to/file.txt.gz` existed.

## Kubernetes Executor
Fixed an issue where log streams were initiated prematurely, before the worker pod reached a running state.
Added support for environment variable definitions.